### PR TITLE
work on parsing emails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ The following field are optional:
   to.
 - `template`: The name of a template to use for the email. There are
   currently three templates available:
-
   - `default`: A simple template with a header and footer in the
     Datasektionen style. This is the default if **no template** is
     specified.

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,7 @@ pub enum Error {
     TemplateLoad(String),
     Attachment(String),
     NotASCII(String),
+    InvalidAddress(String),
     EmailBody(String),
 }
 
@@ -52,6 +53,7 @@ impl Display for Error {
             Error::EmailBody(msg) => write!(f, "Failed to process email body: {}", msg),
             Error::NotASCII(field) => write!(f, "Contains non-ASCII characters: {}", field),
             Error::MissingContent => write!(f, "No 'html' or 'content' field provided."),
+            Error::InvalidAddress(msg) => write!(f, "Invalid address: {}", msg),
         }
     }
 }
@@ -70,7 +72,8 @@ impl From<&Error> for HttpResponse {
             | Error::InvalidEmailDomain(_)
             | Error::InvalidContentType
             | Error::NotASCII(_)
-            | Error::MissingContent => HttpResponse::BadRequest().body(val.to_string()),
+            | Error::MissingContent
+            | Error::InvalidAddress(_) => HttpResponse::BadRequest().body(val.to_string()),
         }
     }
 }
@@ -92,6 +95,7 @@ impl ResponseError for Error {
             | Error::InvalidEmailDomain(_)
             | Error::InvalidContentType
             | Error::NotASCII(_)
+            | Error::InvalidAddress(_)
             | Error::MissingContent => StatusCode::BAD_REQUEST,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,6 +310,8 @@ async fn send_mail_legacy(
         Either::Right(form) => form.into_inner(),
     };
 
+    debug!("received email request: {:?}", body);
+
     let hive_url = env::var("HIVE_URL")
         .map_err(|e| Error::EnvVarMissing(format!("HIVE_URL missing: {}", e)))?;
 


### PR DESCRIPTION
Now implements the following types of addresses:

* `address@domain.com`
* `Name <address@domain.com>`
* `{"name": "Name", "address": "address@domain.com"}`

call these `<addr>`

And for fields that can accept fields of addresses (to, cc, bcc, replyTo):

* `<addr>`
* `[<addr>, <addr>, ...]`
* `"<addr>, <addr>, ..."` (obviously not the "object variant here")

also has better error messages when passing invalid input, and added some tests for json parsing. Should solve most issues from #1 
